### PR TITLE
Remove node role check

### DIFF
--- a/src/main/java/org/elasticsearch/service/graphite/GraphiteService.java
+++ b/src/main/java/org/elasticsearch/service/graphite/GraphiteService.java
@@ -103,7 +103,7 @@ public class GraphiteService extends AbstractLifecycleComponent<GraphiteService>
                 DiscoveryNode node = clusterService.localNode();
                 boolean isClusterStarted = clusterService.lifecycleState().equals(Lifecycle.State.STARTED);
 
-                if (isClusterStarted && node != null && (node.isMasterNode() || node.isDataNode() || node.isClientNode()) ) {
+                if (isClusterStarted && node != null) {
                     NodeIndicesStats nodeIndicesStats = indicesService.stats(false);
                     CommonStatsFlags commonStatsFlags = new CommonStatsFlags().clear();
                     NodeStats nodeStats = nodeService.stats(commonStatsFlags, true, true, true, true, true, true, true, true, true);


### PR DESCRIPTION
Removing node role check as for client nodes it always returns false for all roles and doesn't report to graphite.